### PR TITLE
Explicitly set S3 bucket to have versioning enabled

### DIFF
--- a/lib/daily-recordings-bucket-stack.ts
+++ b/lib/daily-recordings-bucket-stack.ts
@@ -17,6 +17,7 @@ export class DailyRecordingBucket extends Stack {
     const recordingsBucket = new aws_s3.Bucket(this, "DailyS3Bucket", {
       bucketName: bucketName,
       encryption: aws_s3.BucketEncryption.S3_MANAGED,
+      versioned: true,
     });
 
     const dailySubdomain = this.node.tryGetContext("dailySubdomain");


### PR DESCRIPTION
Thanks for creating this repo, very helpful in getting things setup for cloud storage quickly and confidently. Noticed this 1 small thing when comparing this config with the docs, and thought I'd be helpful and open a PR rather than just complain about it. 

Documentation website states that s3 bucket needs to have versioning enabled on it. Therefore we should setup CDK to create the bucket with that explicit config. 

From the [documentation](https://docs.daily.co/guides/products/live-streaming-recording/storing-recordings-in-a-custom-s3-bucket#s3-bucket-configuration-requirements)
> The target S3 bucket to which you want recordings to be stored can be in any AWS region and must have versioning enabled. Please be sure to select "Enable" under "Bucket Versioning" when creating your S3 bucket for recording storage.